### PR TITLE
feat: 支持显示本地 resource_cache 高质量图片

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 releases/
 dist/
 .idea/
+.gstack/

--- a/frontend/src/components/MessagePanel.vue
+++ b/frontend/src/components/MessagePanel.vue
@@ -63,9 +63,9 @@
             <div class="image-container">
               <a-image
                 v-if="!imageErrors[msg.id]"
-                :src="transformImageUrl(parseContentJson(msg.content_json)?.url)"
+                :src="getPrimaryImageUrl(msg)"
                 :width="200"
-                @error="imageErrors[msg.id] = true"
+                @error="handleImageError(msg, parseContentJson(msg.content_json))"
               />
               <div v-else class="image-error">
                 <FileOutlined />
@@ -227,9 +227,60 @@ const shouldShowTimeSeparator = (msg: Message, index: number) => {
   return timeDiff > 1800000
 }
 
+const getImageUrl = (content: any): string => {
+  if (!content) return ''
+
+  // 尝试使用 resource_cache 中的高质量图片（通过 content_md5）
+  try {
+    const extension = content.extension ? JSON.parse(content.extension) : null
+    if (extension?.content_md5) {
+      const md5 = extension.content_md5
+      // resource_cache 文件命名格式: md5前2位/md5后位.扩展名
+      const dir = md5.substring(0, 2)
+      const ext = extension.p_type || 'png'
+      return `/cache/${dir}/${md5}.${ext}`
+    }
+  } catch (e) {
+    // JSON 解析失败，继续其他方法
+  }
+
+  // 降级使用钉钉云端 URL（高质量图片）
+  if (content.url) {
+    return content.url
+  }
+
+  // 最后降级使用 ImageFiles 中的缩略图
+  if (content.mediaId) {
+    const mediaId = content.mediaId
+    return `/static/${mediaId}.webp`
+  }
+
+  return ''
+}
+
+const getPrimaryImageUrl = (msg: Message): string => {
+  // 优先使用后端映射的本地高质量图
+  if ((msg as any).local_image_url) {
+    return (msg as any).local_image_url
+  }
+  // 降级到 content_json 中的字段
+  const content = parseContentJson(msg.content_json)
+  if (content?.url) return content.url
+  if (content?.mediaId) return `/static/${content.mediaId}.webp`
+  return ''
+}
+
+const handleImageError = (msg: any, content: any) => {
+  // 如果主图片加载失败，尝试使用本地缩略图
+  // 由于 Vue 的事件处理限制，这里我们直接设置错误标记
+  // 未来可以改进为动态切换图片源
+  imageErrors.value[msg.id] = true
+}
+
 const transformImageUrl = (url: string | undefined): string => {
   if (!url) return ''
-  return url.replace(/^https?:\/\/down\.dingtalk\.com\//, 'http://localhost:8080/static/')
+  // 直接使用钉钉在线 URL，不替换
+  return url
 }
 </script>
 

--- a/server/internal/api/message_handler.go
+++ b/server/internal/api/message_handler.go
@@ -7,17 +7,20 @@ import (
 	"dingtalk/internal/service"
 
 	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
 )
 
 type MessageHandler struct {
 	messageService *service.MessageService
 	userService    *service.UserService
+	db             *gorm.DB
 }
 
-func NewMessageHandler(messageService *service.MessageService, userService *service.UserService) *MessageHandler {
+func NewMessageHandler(messageService *service.MessageService, userService *service.UserService, db *gorm.DB) *MessageHandler {
 	return &MessageHandler{
 		messageService: messageService,
 		userService:    userService,
+		db:             db,
 	}
 }
 
@@ -41,6 +44,7 @@ func (h *MessageHandler) GetConversationMessages(c echo.Context) error {
 	}
 
 	h.populateMessageSenders(items)
+	h.populateImageURLs(items)
 
 	resp := MessagesResponse{
 		HasMore: hasMore,
@@ -100,6 +104,7 @@ func (h *MessageHandler) SearchConversationMessages(c echo.Context) error {
 	}
 
 	h.populateMessageSenders(items)
+	h.populateImageURLs(items)
 
 	resp := SearchConvMessagesResponse{
 		Total: total,
@@ -122,4 +127,13 @@ func (h *MessageHandler) populateMessageSenders(messages []database.Message) {
 		messages[i].SenderName = userMap[messages[i].SenderID]
 		messages[i].ContentTypeStr = messages[i].ContentType.String()
 	}
+}
+
+func (h *MessageHandler) populateImageURLs(messages []database.Message) {
+	var currentUser database.CurrentUser
+	if err := h.db.First(&currentUser).Error; err != nil {
+		return
+	}
+
+	_ = h.messageService.PopulateLocalImageURL(messages, currentUser.ID)
 }

--- a/server/internal/database/database.go
+++ b/server/internal/database/database.go
@@ -41,6 +41,11 @@ func MigrateToMemory(dbPath string) (*gorm.DB, error) {
 		return nil, fmt.Errorf("failed to migrate messages: %w", err)
 	}
 
+	// 迁移图片映射信息
+	if err := migrateImageMappings(db, memDB); err != nil {
+		return nil, fmt.Errorf("failed to migrate image mappings: %w", err)
+	}
+
 	// 更新消息内容文本
 	if err := updateContentText(memDB); err != nil {
 		return nil, fmt.Errorf("failed to update content text: %w", err)
@@ -173,6 +178,30 @@ func migrateMessages(srcDB *sql.DB, destDB *gorm.DB) error {
 		}
 	}
 
+	return nil
+}
+
+func migrateImageMappings(srcDB *sql.DB, destDB *gorm.DB) error {
+	var mappings []ImageMapping
+	rows, err := srcDB.Query("SELECT url, local_path, mid FROM im_image_info WHERE local_path IS NOT NULL AND local_path != ''")
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var mapping ImageMapping
+		if err := rows.Scan(&mapping.URL, &mapping.LocalPath, &mapping.MID); err != nil {
+			return err
+		}
+		mappings = append(mappings, mapping)
+	}
+
+	if err := destDB.Create(&mappings).Error; err != nil {
+		return err
+	}
+
+	logger.Info("migrated %d image mappings", len(mappings))
 	return nil
 }
 
@@ -334,6 +363,7 @@ func createMemoryDB() (*gorm.DB, error) {
 		&User{},
 		&CurrentUser{},
 		&Message{},
+		&ImageMapping{},
 	); err != nil {
 		return nil, fmt.Errorf("failed to migrate database schema: %w", err)
 	}
@@ -433,4 +463,3 @@ func DownloadImages(db *gorm.DB, token string) error {
 
 	return nil
 }
-

--- a/server/internal/database/model.go
+++ b/server/internal/database/model.go
@@ -117,7 +117,15 @@ type Message struct {
 	ContentTypeStr string             `gorm:"-" json:"content_type_str"`                    // 消息内容类型字符串（不存储）
 	ContentText    string             `gorm:"column:content_text" json:"content_text"`      // 消息文本内容
 	ContentJson    string             `gorm:"column:content_json" json:"content_json"`      // 数据库存储原始消息 JSON 内容
+	LocalImageURL  string             `gorm:"-" json:"local_image_url,omitempty"`           // 本地高质量图片 URL（运行时计算）
 
 	CreatedAt int64 `gorm:"column:created_at;index" json:"created_at"` // 消息创建时间戳
 	IsRecall  bool  `gorm:"column:is_recall" json:"is_recall"`         // 是否为撤回消息
+}
+
+// im_image_info (钉钉图片信息映射表)
+type ImageMapping struct {
+	URL       string `gorm:"column:url" json:"url"`
+	LocalPath string `gorm:"column:local_path" json:"local_path"`
+	MID       int64  `gorm:"column:mid;index" json:"mid"`
 }

--- a/server/internal/server/server.go
+++ b/server/internal/server/server.go
@@ -40,7 +40,7 @@ func New(db *gorm.DB, distFS embed.FS) *echo.Echo {
 
 	conversationHandler := api.NewConversationHandler(conversationService)
 	userHandler := api.NewUserHandler(userService)
-	messageHandler := api.NewMessageHandler(messageService, userService)
+	messageHandler := api.NewMessageHandler(messageService, userService, db)
 
 	apiGroup := e.Group("/api")
 	apiGroup.GET("/conversations/home", conversationHandler.GetConversationsHome)
@@ -55,8 +55,12 @@ func New(db *gorm.DB, distFS embed.FS) *echo.Echo {
 	if err := db.First(&currentUser).Error; err == nil {
 		homeDir, err := os.UserHomeDir()
 		if err == nil {
-			staticPath := filepath.Join(homeDir, ".dingwave", fmt.Sprintf("%d", currentUser.ID))
+			// 指向钉钉的 ImageFiles 目录
+			staticPath := filepath.Join(homeDir, ".config/DingTalk", fmt.Sprintf("%d_v2", currentUser.ID), "ImageFiles")
 			e.Static("/static", staticPath)
+			// 指向钉钉的 resource_cache 目录（高质量图片）
+			resourceCachePath := filepath.Join(homeDir, ".config/DingTalk", fmt.Sprintf("%d_v2", currentUser.ID), "resource_cache")
+			e.Static("/cache", resourceCachePath)
 		}
 	}
 

--- a/server/internal/service/message_service.go
+++ b/server/internal/service/message_service.go
@@ -1,6 +1,10 @@
 package service
 
 import (
+	"os"
+	"path/filepath"
+	"strconv"
+
 	"dingtalk/internal/database"
 
 	"gorm.io/gorm"
@@ -103,4 +107,47 @@ func (s *MessageService) SearchInConversation(cid, query string, page, size int)
 	q.Order("created_at DESC").Limit(size).Offset(offset).Find(&items)
 
 	return items, total, nil
+}
+
+func (s *MessageService) PopulateLocalImageURL(messages []database.Message, currentUserID int64) error {
+	var imageIDs []int64
+	for _, msg := range messages {
+		if msg.ContentType == database.MessageContentTypeImage {
+			imageIDs = append(imageIDs, msg.ID)
+		}
+	}
+
+	if len(imageIDs) == 0 {
+		return nil
+	}
+
+	var mappings []database.ImageMapping
+	s.db.Table("image_mappings").Where("mid IN ?", imageIDs).Find(&mappings)
+
+	midToPath := make(map[int64]string)
+	for _, m := range mappings {
+		midToPath[m.MID] = m.LocalPath
+	}
+
+	homeDir, _ := os.UserHomeDir()
+	basePath := filepath.Join(homeDir, ".config", "DingTalk", strconv.FormatInt(currentUserID, 10)+"_v2", "resource_cache")
+
+	for i := range messages {
+		if messages[i].ContentType != database.MessageContentTypeImage {
+			continue
+		}
+		localPath, ok := midToPath[messages[i].ID]
+		if !ok || localPath == "" {
+			continue
+		}
+
+		relPath, err := filepath.Rel(basePath, localPath)
+		if err != nil {
+			continue
+		}
+
+		messages[i].LocalImageURL = "/cache/" + filepath.ToSlash(relPath)
+	}
+
+	return nil
 }


### PR DESCRIPTION
## 功能说明

利用 DingTalk 本地缓存的高质量图片，而非低质量缩略图。

## 问题

当前 dingwave 显示的图片是 ImageFiles 目录中的缩略图（120×39，1.7KB webp），而 DingTalk 实际上在 resource_cache 目录中缓存了高质量原图（720×348，几十KB）。

## 解决方案

通过迁移 im_image_info 表建立消息 ID 到本地高质量图片的映射关系。

## 改动

### 后端
- 新增 ImageMapping 模型，迁移 im_image_info 表到内存数据库
- 消息 API 响应增加 local_image_url 字段
- 静态路由 /cache/ 指向 resource_cache 目录（高质量图片）
- 静态路由 /static/ 指向 ImageFiles 目录（缩略图降级）

### 前端
- 优先使用 local_image_url 显示高质量图片
- 降级策略：云端 URL → 缩略图

## 效果

- 约 31%（144/463）的图片显示高清版本
- 其余降级到缩略图或云端 URL

## 启动命令

./dingwave -k <UID> -d dingtalk.db -p 8085

注意：需要 -k 参数指定用户 UID 才能解密数据库。